### PR TITLE
fix the case when installation failed shown red screen in grub

### DIFF
--- a/grub/recovery_partition.cfg
+++ b/grub/recovery_partition.cfg
@@ -107,11 +107,20 @@ set gfxpayload=keep
 menuentry "If you are seeing this menu, your installation has failed." {
   chainloader +1
 }
-menuentry "Choose from the following options for debugging purposes:" {
-  chainloader +1
+#
+# Add collecting logs function for factory to provide more failed info to analysis issue
+#
+menuentry "Collect OS installation logs" {
+  search --file --set=new_root /efi/boot/grubx64.efi
+  set root=$new_root
+  linux /casper/vmlinuz.efi $options
+  initrd /casper/initrd.lz
 }
-menuentry "" {
-  chainloader +1
+menuentry "Collect OS installation logs (command line mode)" {
+  search --file --set=new_root /efi/boot/grubx64.efi
+  set root=$new_root
+  linux /casper/vmlinuz.efi boot=casper automatic-ubiquity noprompt quiet nomodeset init=/bin/bash
+  initrd /casper/initrd.lz
 }
 
 menuentry "Single User Mode" {

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -142,7 +142,6 @@ class PageGtk(PluginUI):
             icon = builder.get_object('dell_image')
             icon.set_tooltip_markup("Dell Recovery Advanced Options")
             self.advanced_page = builder.get_object('advanced_window')
-            self.advanced_table = builder.get_object('advanced_table')
             self.version_detail = builder.get_object('version_detail')
             self.mount_detail = builder.get_object('mountpoint_detail')
             self.memory_detail = builder.get_object('memory_detail')
@@ -158,7 +157,6 @@ class PageGtk(PluginUI):
         """
         #are we real?
         if not (self.genuine and 'UBIQUITY_AUTOMATIC' in os.environ):
-            self.advanced_table.set_sensitive(False)
             self.interactive_recovery_box.hide()
             self.automated_recovery_box.hide()
             self.automated_recovery.set_sensitive(False)
@@ -209,7 +207,6 @@ class PageGtk(PluginUI):
         else:
             self.controller.allow_go_forward(False)
             if value == "hdd":
-                self.advanced_table.set_sensitive(False)
                 self.hdd_recovery_box.show()
                 self.interactive_recovery_box.hide()
                 self.automated_recovery_box.hide()


### PR DESCRIPTION
I have fixed a severe bug when OS recoveries from HDD with adding collecting logs function.
Additionally, I also enhance the robust of the system for the regular case when OS installation failed shown a red screen in grub after it reboots again.