### PR TITLE
Fix the tarfile usage of python3. Closes: #34

### DIFF
--- a/Dell/recovery_backend.py
+++ b/Dell/recovery_backend.py
@@ -347,7 +347,7 @@ class Backend(dbus.service.Object):
                 nested = False
                 rfd = tarfile.open(fishie)
                 for member in rfd.getmembers():
-                    name = member.get_info(encoding='UTF-8', errors='strict')['name']
+                    name = member.get_info()['name']
                     if name.endswith('.html'):
                         nested = name
                         break


### PR DESCRIPTION
There are no 'encoding' and 'errors' for this function call in python3.