### PR TITLE
Move the 99_dell_recovery grub creation from dell-recovery.py to dell-bootstrap.py

### DIFF
--- a/Dell/recovery_backend.py
+++ b/Dell/recovery_backend.py
@@ -826,10 +826,10 @@ arch %s, distributor_str %s" % (bto_version, distributor, release, arch, distrib
             raise RestoreFailed("error setting one time grub entry")
 
         if reboot:
-            logging.debug("Prepare to reboot using gdbus")
-            ret = subprocess.call(['/usr/bin/gdbus', 'call', '-y', '-d', 'org.freedesktop.systemd1', '-o', '/org/freedesktop/systemd1', '-m', 'org.freedesktop.systemd1.Manager.Reboot'])
+            logging.debug("Prepare to reboot")
+            ret = subprocess.call(["/sbin/reboot", "--force"])
             if ret is not 0:
-                raise RestoreFailed("error invoking gdbus to reboot")
+                raise RestoreFailed("error invoking reboot")
 
 
     @dbus.service.method(DBUS_INTERFACE_NAME,

--- a/Dell/recovery_backend.py
+++ b/Dell/recovery_backend.py
@@ -773,14 +773,14 @@ arch %s, distributor_str %s" % (bto_version, distributor, release, arch, distrib
     @dbus.service.method(DBUS_INTERFACE_NAME,
         in_signature = '', out_signature = '', sender_keyword = 'sender',
         connection_keyword = 'conn')
-    def enable_boot_to_restore(self, sender=None, conn=None):
+    def enable_boot_to_restore(self, reboot=False, sender=None, conn=None):
         """Enables the default one-time boot option to be recovery"""
         self._reset_timeout()
         self._check_polkit_privilege(sender, conn, 'com.dell.recoverymedia.restore')
-        logging.debug("enable_boot_to_restore")
-        self._prepare_reboot("99_dell_recovery")
+        logging.debug("enable_boot_to_restore:reboot=%s" % reboot)
+        self._prepare_reboot("99_dell_recovery", reboot)
 
-    def _prepare_reboot(self, dest):
+    def _prepare_reboot(self, dest, reboot):
         """Helper function to reboot into an entry"""
         #find our one time boot entry
         if not os.path.exists("/etc/grub.d/%s" % dest):
@@ -824,6 +824,12 @@ arch %s, distributor_str %s" % (bto_version, distributor, release, arch, distrib
         ret = subprocess.call(['/usr/sbin/grub-reboot', entry])
         if ret is not 0:
             raise RestoreFailed("error setting one time grub entry")
+
+        if reboot:
+            logging.debug("Prepare to reboot using gdbus")
+            ret = subprocess.call(['/usr/bin/gdbus', 'call', '-y', '-d', 'org.freedesktop.systemd1', '-o', '/org/freedesktop/systemd1', '-m', 'org.freedesktop.systemd1.Manager.Reboot'])
+            if ret is not 0:
+                raise RestoreFailed("error invoking gdbus to reboot")
 
 
     @dbus.service.method(DBUS_INTERFACE_NAME,

--- a/Dell/recovery_backend.py
+++ b/Dell/recovery_backend.py
@@ -771,9 +771,9 @@ arch %s, distributor_str %s" % (bto_version, distributor, release, arch, distrib
         self.report_package_info(valid, description, error_warning)
 
     @dbus.service.method(DBUS_INTERFACE_NAME,
-        in_signature = '', out_signature = '', sender_keyword = 'sender',
+        in_signature = 'b', out_signature = '', sender_keyword = 'sender',
         connection_keyword = 'conn')
-    def enable_boot_to_restore(self, reboot=False, sender=None, conn=None):
+    def enable_boot_to_restore(self, reboot, sender=None, conn=None):
         """Enables the default one-time boot option to be recovery"""
         self._reset_timeout()
         self._check_polkit_privilege(sender, conn, 'com.dell.recoverymedia.restore')

--- a/Dell/recovery_common.py
+++ b/Dell/recovery_common.py
@@ -188,7 +188,7 @@ def check_version(package='dell-recovery'):
               file=sys.stderr)
         return "unknown"
 
-def process_conf_file(original, new, uuid, number, recovery_text=''):
+def process_conf_file(original, new, uuid, number, recovery_text='', recovery_type='hdd'):
     """Replaces all instances of a partition, OS, and extra in a conf type file
        Generally used for things that need to touch grub"""
     if not os.path.isdir(os.path.split(new)[0]):
@@ -212,6 +212,8 @@ def process_conf_file(original, new, uuid, number, recovery_text=''):
                     line = line.replace("#PARTITION#", number)
                 if "#OS#" in line:
                     line = line.replace("#OS#", "%s %s" % (release["ID"], release["RELEASE"]))
+                if "#REC_TYPE#" in line:
+                    line = line.replace("#REC_TYPE#", recovery_type)
                 output.write(line)
 
 def fetch_output(cmd, data='', environment=os.environ):
@@ -634,6 +636,21 @@ def mark_unconditional_debs(add_directory=''):
                         to_install.append(package)
 
     return to_install
+
+def create_grub_entries(rec_type='hdd'):
+    '''Create GRUB entry for dell-recovery during ubiquity installation'''
+    env = os.environ
+    rpart = find_factory_partition_stats()
+    #create the grub entry only when both recovery partition and /cdrom/.disk/info exist
+    if rpart and os.path.exists('/cdrom/.disk/info'):
+        rec_text = 'Restore OS to factory state'
+        process_conf_file(original = '/usr/share/dell/grub/99_dell_recovery', \
+                          new = '/target/etc/grub.d/99_dell_recovery',        \
+                          uuid = str(rpart["uuid"]),                          \
+                          number = str(rpart["number"]),                      \
+                          recovery_text = rec_text,
+                          recovery_type = rec_type)
+        os.chmod('/target/etc/grub.d/99_dell_recovery', 0o755)
 
 def dbus_sync_call_signal_wrapper(dbus_iface, func, handler_map, *args, **kwargs):
     '''Run a D-BUS method call while receiving signals.

--- a/Dell/recovery_gtk.py
+++ b/Dell/recovery_gtk.py
@@ -135,7 +135,8 @@ class DellRecoveryToolGTK:
                 try:
                     dbus_sync_call_signal_wrapper(self.backend(),
                                                   "enable_boot_to_restore",
-                                                  {})
+                                                  {},
+                                                  False)
                     proc = subprocess.Popen(["gnome-session-quit", "--reboot"])
                     self.destroy()
                 except dbus.DBusException as msg:

--- a/dell-restore-system
+++ b/dell-restore-system
@@ -1,0 +1,89 @@
+#! /usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Dell Recovery Restore system command line
+#
+# Copyright (C) 2017 Dell Inc,
+#   Author: Mario Limonciello
+#
+# This is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 2 of the License, or at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this application; if not, write to the Free Software Foundation, Inc., 51
+# Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+##################################################################################
+
+from Dell.recovery_common import (find_partition, check_version, DBUS_INTERFACE_NAME,
+                                  DBUS_BUS_NAME, dbus_sync_call_signal_wrapper,
+                                  PermissionDeniedByPolicy)
+import optparse
+import os
+import subprocess
+import sys
+#Translation support
+from gettext import gettext as _
+
+usage = '%prog [options]'
+parser = optparse.OptionParser(usage=usage)
+parser.set_defaults(
+    version=''
+    )
+parser.add_option('-c', '--check-version', dest='checkversion', action='store_true',
+                  help='Show the version information.')
+parser.add_option('-y', '--yes', dest='yes', action='store_true',
+                  help="Restore the system without user's confirmation.")
+(options, args) = parser.parse_args()
+
+if __name__ == '__main__':
+    if options.checkversion:
+        print("Version: %s" % check_version())
+    else:
+        if not options.yes:
+            confirm = input('Would you want to restore the system?(y/n)')
+            if not confirm.lower() == 'yes' and not confirm.lower()=='y':
+                sys.stdout.write("Aborted.\n")
+                sys.exit(0)
+        
+        import dbus.mainloop.glib
+        dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+        recovery = find_partition()
+
+        #If we don't find an RP, throw error.
+        if not recovery:
+            sys.stderr.write("ERR: No recovery partition could be found to restore the system.\n")
+            sys.exit(1)
+    
+        #don't ever autostart again
+        autostart=os.path.expanduser("~/.config/autostart/dell-recovery.desktop")
+        reminder = os.path.expanduser("~/.config/dell-recovery/reminder")
+        for item in (autostart, reminder):
+            if os.path.exists(item):
+                os.remove(item)
+        
+        #invoke dbus to restore the system
+        try:
+            bus = dbus.SystemBus()
+            dbus_iface = dbus.Interface(bus.get_object(DBUS_BUS_NAME,
+                                        '/RecoveryMedia'),
+                                        DBUS_INTERFACE_NAME)
+            dbus_sync_call_signal_wrapper(dbus_iface,
+                                          "enable_boot_to_restore",
+                                          {})
+            subprocess.Popen(["reboot", "--force"])
+        except dbus.DBusException as ex:
+            if ex.get_dbus_name() == 'org.freedesktop.DBus.Error.FileNotFound':
+                text = _("Cannot connect to dbus")
+            if ex.get_dbus_name() == PermissionDeniedByPolicy._dbus_error_name:
+                text = _("Permission Denied")
+            else:
+                text = msg.get_dbus_message()
+            sys.stderr.write(" %s\n" % text)
+            sys.exit(1)

--- a/dell-restore-system
+++ b/dell-restore-system
@@ -4,7 +4,7 @@
 # Dell Recovery Restore system command line
 #
 # Copyright (C) 2017 Dell Inc,
-#   Author: Mario Limonciello
+#   Author: Mario Limonciello/Jude Hung
 #
 # This is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License as published by the Free

--- a/dell-restore-system
+++ b/dell-restore-system
@@ -44,12 +44,12 @@ parser.add_option('-y', '--yes', dest='yes', action='store_true',
 
 if __name__ == '__main__':
     if options.checkversion:
-        print("Version: %s" % check_version())
+        print("%s %s" % (_("Version:"), check_version()))
     else:
         if not options.yes:
-            confirm = input('Would you want to restore the system?(y/n)')
+            confirm = input(_("Would you want to restore the system? (y/n)"))
             if not confirm.lower() == 'yes' and not confirm.lower()=='y':
-                sys.stdout.write("Aborted.\n")
+                sys.stdout.write("%s\n" % _("Aborted."))
                 sys.exit(0)
         
         import dbus.mainloop.glib
@@ -58,7 +58,7 @@ if __name__ == '__main__':
 
         #If we don't find an RP, throw error.
         if not recovery:
-            sys.stderr.write("ERR: No recovery partition could be found to restore the system.\n")
+            sys.stderr.write("%s\n" %_("ERR: No recovery partition could be found to restore the system."))
             sys.exit(1)
     
         #don't ever autostart again
@@ -85,5 +85,5 @@ if __name__ == '__main__':
                 text = _("Permission Denied")
             else:
                 text = ex.get_dbus_message()
-            sys.stderr.write(" %s\n" % text)
+            sys.stderr.write("%s\n" % text)
             sys.exit(1)

--- a/dell-restore-system
+++ b/dell-restore-system
@@ -76,8 +76,8 @@ if __name__ == '__main__':
                                         DBUS_INTERFACE_NAME)
             dbus_sync_call_signal_wrapper(dbus_iface,
                                           "enable_boot_to_restore",
-                                          {})
-            subprocess.Popen(["reboot", "--force"])
+                                          {},
+                                          True)
         except dbus.DBusException as ex:
             if ex.get_dbus_name() == 'org.freedesktop.DBus.Error.FileNotFound':
                 text = _("Cannot connect to dbus")

--- a/dell-restore-system
+++ b/dell-restore-system
@@ -84,6 +84,6 @@ if __name__ == '__main__':
             if ex.get_dbus_name() == PermissionDeniedByPolicy._dbus_error_name:
                 text = _("Permission Denied")
             else:
-                text = msg.get_dbus_message()
+                text = ex.get_dbus_message()
             sys.stderr.write(" %s\n" % text)
             sys.exit(1)

--- a/grub/99_dell_recovery
+++ b/grub/99_dell_recovery
@@ -30,7 +30,7 @@ menuentry "#RECOVERY_TEXT#" {
             set options="\$options dell-recovery/dual_boot=true"
         fi 
 
-        linux   /casper/vmlinuz.efi dell-recovery/recovery_type=hdd \$uuid_options \$options
+        linux   /casper/vmlinuz.efi dell-recovery/recovery_type=#REC_TYPE# \$uuid_options \$options
 	initrd	/casper/initrd.lz
 }
 EOF

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
                 ('lib/ubiquity/plugins', glob.glob('ubiquity/*.py')),
                 ('share/ubiquity/gtk', glob.glob('ubiquity/*.ui')),
                 ('share/ubiquity', ['ubiquity/dell-bootstrap'])]+I18NFILES,
-    scripts=["dell-recovery"],
+    scripts=["dell-recovery", "dell-restore-system"],
 
     cmdclass = { 'build': SecureBootBuild,
                  'build_i18n': build_i18n.build_i18n,

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -1226,6 +1226,15 @@ class Install(InstallPlugin):
                 if not found:
                     wfd.write("GRUB_DISABLE_OS_PROBER=true\n")
 
+            #set default recovery_type of 99_dell_recovery grub as 'hdd' for non-Wyse platforms
+            recovery_type = 'hdd'
+            #if wyse mode is on (dell-recovery/mode == 'wyse'), set the recovery_type to be 'factory'
+            #as Wyse platforms will always skip the "Restore OS Linux partition" dialog
+            if self.db.get('dell-recovery/mode')=='wyse':
+                recovery_type = 'factory'
+            #create 99_dell_recovery grub
+            magic.create_grub_entries(recovery_type)
+
         #for tos
         try:
             destination = progress.get('dell-recovery/destination')

--- a/ubiquity/dell-recovery.py
+++ b/ubiquity/dell-recovery.py
@@ -185,20 +185,6 @@ class Install(InstallPlugin):
         lang = progress.get('debian-installer/locale')
         env['LANG'] = lang
 
-        #can also expect that this was mounted at /cdrom during OOBE
-        rpart = magic.find_factory_partition_stats()
-        if rpart and os.path.exists('/cdrom/.disk/info.recovery'):
-            rec_text = progress.get('ubiquity/text/99_grub_menu')
-            magic.process_conf_file(original = '/usr/share/dell/grub/99_dell_recovery', \
-                                    new = '/etc/grub.d/99_dell_recovery',               \
-                                    uuid = str(rpart["uuid"]),                          \
-                                    number = str(rpart["number"]),                      \
-                                    recovery_text = rec_text)
-
-            os.chmod('/etc/grub.d/99_dell_recovery', 0o755)
-
-        subprocess.call(['update-grub'],env=env)
-
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         self.progress = progress
 


### PR DESCRIPTION
## 1. Move the 99_dell_recovery grub creation from oem-config to dell-bootstrap.py

Some platforms would like to skip entire OOBE stage (oem-config mode) to achieve silent install.  However, there is a side effect to skip entire oem-config:  99_dell_recovery grub creation will be skipped, thus preventing the platforms from restoring system to factory state because 99_dell_recovery grub is mandatory to restore the system.

This update is to move the 99_dell_recovery grub creation from dell-recovery.py(oem-config OOBE stage) to dell-bootstrap.py, so that for platforms that would like to skip oem-config phase still can restore the system to factory state.

## 2. Update the 99_dell_recovery grub with replaceable dell-recovery/recovery_type preseed

There is a hard requirement from some platforms that "Restore Linux OS partitions" dialog should be skipped as such platforms are managed by IT admins, who will not go each systems and manually select the radio button.

This update is to make 99_dell_recovery grub with replaceable dell-recovery/recovery_type preseed, so that 

- platforms NOT to skip "Restore Linux OS partitions": dell-recovery/recovery_type = hdd
- platforms to skip "Restore Linux OS partitions": dell-recovery/recovery_type = factory

