### PR TITLE
Move the 99_dell_recovery grub creation from oem-config to dell-bootstrap.py and also Update the 99_dell_recovery grub with replaceable dell-recovery/recovery_type preseed

### DIFF
--- a/Dell/recovery_common.py
+++ b/Dell/recovery_common.py
@@ -637,20 +637,21 @@ def mark_unconditional_debs(add_directory=''):
 
     return to_install
 
-def create_grub_entries(rec_type='hdd'):
+def create_grub_entries(target_dir='/target', rec_type='hdd'):
     '''Create GRUB entry for dell-recovery during ubiquity installation'''
     env = os.environ
     rpart = find_factory_partition_stats()
+    target_grub = '%s/etc/grub.d/99_dell_recovery' % target_dir
     #create the grub entry only when recovery partition exists
     if rpart:
         rec_text = 'Restore OS to factory state'
         process_conf_file(original = '/usr/share/dell/grub/99_dell_recovery', \
-                          new = '/target/etc/grub.d/99_dell_recovery',        \
+                          new = target_grub,                                  \
                           uuid = str(rpart["uuid"]),                          \
                           number = str(rpart["number"]),                      \
                           recovery_text = rec_text,
                           recovery_type = rec_type)
-        os.chmod('/target/etc/grub.d/99_dell_recovery', 0o755)
+        os.chmod(target_grub, 0o755)
 
 def dbus_sync_call_signal_wrapper(dbus_iface, func, handler_map, *args, **kwargs):
     '''Run a D-BUS method call while receiving signals.

--- a/Dell/recovery_common.py
+++ b/Dell/recovery_common.py
@@ -641,8 +641,8 @@ def create_grub_entries(rec_type='hdd'):
     '''Create GRUB entry for dell-recovery during ubiquity installation'''
     env = os.environ
     rpart = find_factory_partition_stats()
-    #create the grub entry only when both recovery partition and /cdrom/.disk/info exist
-    if rpart and os.path.exists('/cdrom/.disk/info'):
+    #create the grub entry only when recovery partition exists
+    if rpart:
         rec_text = 'Restore OS to factory state'
         process_conf_file(original = '/usr/share/dell/grub/99_dell_recovery', \
                           new = '/target/etc/grub.d/99_dell_recovery',        \

--- a/Dell/recovery_common.py
+++ b/Dell/recovery_common.py
@@ -188,7 +188,7 @@ def check_version(package='dell-recovery'):
               file=sys.stderr)
         return "unknown"
 
-def process_conf_file(original, new, uuid, number, recovery_text=''):
+def process_conf_file(original, new, uuid, number, recovery_text='', recovery_type='hdd'):
     """Replaces all instances of a partition, OS, and extra in a conf type file
        Generally used for things that need to touch grub"""
     if not os.path.isdir(os.path.split(new)[0]):
@@ -212,6 +212,8 @@ def process_conf_file(original, new, uuid, number, recovery_text=''):
                     line = line.replace("#PARTITION#", number)
                 if "#OS#" in line:
                     line = line.replace("#OS#", "%s %s" % (release["ID"], release["RELEASE"]))
+                if "#REC_TYPE#" in line:
+                    line = line.replace("#REC_TYPE#", recovery_type)
                 output.write(line)
 
 def fetch_output(cmd, data='', environment=os.environ):
@@ -634,6 +636,21 @@ def mark_unconditional_debs(add_directory=''):
                         to_install.append(package)
 
     return to_install
+
+def create_grub_entries(rec_type='hdd'):
+    '''Create GRUB entry for dell-recovery during ubiquity installation'''
+    env = os.environ
+    rpart = find_factory_partition_stats()
+    #create the grub entry only when both recovery partition and /cdrom/.disk/info exist
+    if rpart and os.path.exists('/cdrom/.disk/info'):
+        rec_text = 'Restore OS to factory state'
+        process_conf_file(original = '/usr/share/dell/grub/99_dell_recovery', \
+                          new = '/target/etc/grub.d/99_dell_recovery',        \
+                          uuid = str(rpart["uuid"]),                          \
+                          number = str(rpart["number"]),                      \
+                          recovery_text = rec_text,
+                          recovery_type = rec_type)
+        os.chmod('/target/etc/grub.d/99_dell_recovery', 0o755)
 
 def dbus_sync_call_signal_wrapper(dbus_iface, func, handler_map, *args, **kwargs):
     '''Run a D-BUS method call while receiving signals.

--- a/debian/dell-recovery.templates
+++ b/debian/dell-recovery.templates
@@ -1,3 +1,8 @@
+Template: dell-recovery/wyse_mode
+Type: boolean
+Default: false
+Description: for internal use; determines if wyse mode is on.
+
 Template: dell-recovery/dual_boot
 Type: boolean
 Default: false

--- a/grub/99_dell_recovery
+++ b/grub/99_dell_recovery
@@ -30,7 +30,7 @@ menuentry "#RECOVERY_TEXT#" {
             set options="\$options dell-recovery/dual_boot=true"
         fi 
 
-        linux   /casper/vmlinuz.efi dell-recovery/recovery_type=hdd \$uuid_options \$options
+        linux   /casper/vmlinuz.efi dell-recovery/recovery_type=#REC_TYPE# \$uuid_options \$options
 	initrd	/casper/initrd.lz
 }
 EOF

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -393,7 +393,7 @@ class Page(Plugin):
 
        # check dual boot or not
         try:
-            if self.db.get('dell-recovery/dual_boot')=='true':
+            if self.db.get('dell-recovery/dual_boot') == 'true':
            ##dual boot get the partition number of OS and swap
                 os_label = self.db.get('dell-recovery/os_partition')
                 os_part,swap_part = self.dual_partition_num(os_label)
@@ -1230,7 +1230,7 @@ class Install(InstallPlugin):
             recovery_type = 'hdd'
             #if wyse mode is on (dell-recovery/mode == 'wyse'), set the recovery_type to be 'factory'
             #as Wyse platforms will always skip the "Restore OS Linux partition" dialog
-            if self.db.get('dell-recovery/mode')=='wyse':
+            if self.db.get('dell-recovery/wyse_mode') == 'true':
                 recovery_type = 'factory'
             #create 99_dell_recovery grub
             magic.create_grub_entries(recovery_type)

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -1233,7 +1233,7 @@ class Install(InstallPlugin):
             if self.db.get('dell-recovery/wyse_mode') == 'true':
                 recovery_type = 'factory'
             #create 99_dell_recovery grub
-            magic.create_grub_entries(recovery_type)
+            magic.create_grub_entries(self.target, recovery_type)
 
         #for tos
         try:

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -1226,6 +1226,15 @@ class Install(InstallPlugin):
                 if not found:
                     wfd.write("GRUB_DISABLE_OS_PROBER=true\n")
 
+            #set default recovery_type of 99_dell_recovery grub as 'hdd' for non-Wyse platforms
+            recovery_type = 'hdd'
+            #if wyse mode is on (dell-recovery/mode == 'wyse'), set the recovery_type to be 'factory'
+            #as Wyse platforms will always skip the "Restore OS Linux partition" dialog
+            if self.db.get('dell-recovery/mode')=='wyse':
+                recovery_type = 'factory'
+            #create 99_dell_recovery grub
+            magic.create_grub_entries(recovery_type)
+
         #for tos
         try:
             destination = progress.get('dell-recovery/destination')

--- a/ubiquity/dell-recovery.py
+++ b/ubiquity/dell-recovery.py
@@ -185,20 +185,6 @@ class Install(InstallPlugin):
         lang = progress.get('debian-installer/locale')
         env['LANG'] = lang
 
-        #can also expect that this was mounted at /cdrom during OOBE
-        rpart = magic.find_factory_partition_stats()
-        if rpart and os.path.exists('/cdrom/.disk/info.recovery'):
-            rec_text = progress.get('ubiquity/text/99_grub_menu')
-            magic.process_conf_file(original = '/usr/share/dell/grub/99_dell_recovery', \
-                                    new = '/etc/grub.d/99_dell_recovery',               \
-                                    uuid = str(rpart["uuid"]),                          \
-                                    number = str(rpart["number"]),                      \
-                                    recovery_text = rec_text)
-
-            os.chmod('/etc/grub.d/99_dell_recovery', 0o755)
-
-        subprocess.call(['update-grub'],env=env)
-
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         self.progress = progress
 


### PR DESCRIPTION
## 1. Move the 99_dell_recovery grub creation from oem-config to dell-bootstrap.py

Some platforms would like to skip entire OOBE stage (oem-config mode) to achieve silent install.  However, there is a side effect to skip entire oem-config:  99_dell_recovery grub creation will be skipped. 
 As [99_dell_recovery grub is mandatory to restore the system](https://github.com/dell/dell-recovery/blob/master/Dell/recovery_gtk.py#L70), this side effect will prevent users from restoring the system through dell-recovery.

This PR update is to move the 99_dell_recovery grub creation from dell-recovery.py(oem-config OOBE stage) to dell-bootstrap.py, so that restore system functionality could still work for platforms that would like to skip oem-config phase.

## 2. Update the 99_dell_recovery grub with replaceable dell-recovery/recovery_type preseed

There is a hard requirement from some Dell platforms that "Restore Linux OS partitions" dialog should be skipped as such platforms are remotely managed by IT admins, who will not go to each systems and manually select the radio button to restore the system.

This update is to make 99_dell_recovery grub with replaceable dell-recovery/recovery_type preseed, so that 

- platforms NOT to skip "Restore Linux OS partitions": dell-recovery/recovery_type = hdd
- platforms to skip "Restore Linux OS partitions": dell-recovery/recovery_type = factory