### PR TITLE
filter out ":amd64" string when comparing new installed packages name…

### DIFF
--- a/late/scripts/chroot.sh
+++ b/late/scripts/chroot.sh
@@ -146,7 +146,8 @@ fi
 #check the packages installed or not
 if [ -f "$TARGET/tmp/apt-installed" ]; then
     mv $TARGET/tmp/apt-installed $TARGET/var/lib/ubiquity/dell-apt
-    grep -x -f $TARGET/var/lib/ubiquity/dell-apt $TARGET/var/lib/ubiquity/installed-packages > $TARGET/var/lib/ubiquity/dell_installed
+    sed 's/:amd64//g' $TARGET/var/lib/ubiquity/installed-packages > $TARGET/var/lib/ubiquity/installed-packages-filtered
+    grep -x -f $TARGET/var/lib/ubiquity/dell-apt $TARGET/var/lib/ubiquity/installed-packages-filtered > $TARGET/var/lib/ubiquity/dell_installed
     awk '{print $0}' $TARGET/var/lib/ubiquity/dell-apt $TARGET/var/lib/ubiquity/dell_installed |sort |uniq -u > $TARGET/var/lib/ubiquity/dell_uninstalled
 fi
 

--- a/late/scripts/chroot.sh
+++ b/late/scripts/chroot.sh
@@ -146,7 +146,7 @@ fi
 #check the packages installed or not
 if [ -f "$TARGET/tmp/apt-installed" ]; then
     mv $TARGET/tmp/apt-installed $TARGET/var/lib/ubiquity/dell-apt
-    sed 's/:amd64//g' $TARGET/var/lib/ubiquity/installed-packages > $TARGET/var/lib/ubiquity/installed-packages-filtered
+    sed "s/:$(dpkg --print-architecture)//g" $TARGET/var/lib/ubiquity/installed-packages > $TARGET/var/lib/ubiquity/installed-packages-filtered
     grep -x -f $TARGET/var/lib/ubiquity/dell-apt $TARGET/var/lib/ubiquity/installed-packages-filtered > $TARGET/var/lib/ubiquity/dell_installed
     awk '{print $0}' $TARGET/var/lib/ubiquity/dell-apt $TARGET/var/lib/ubiquity/dell_installed |sort |uniq -u > $TARGET/var/lib/ubiquity/dell_uninstalled
 fi


### PR DESCRIPTION
… (#47)

because of some installed package have postfix ":amd64", it will
confuse the logic of commit "f352bd" for #28 and treat it as a failure.

Signed-off-by: Alex Tu <alex.tu@canonical.com>