### PR TITLE
Add an option for dell-bto-autobuilder not to update dell-recovery au…

### DIFF
--- a/Dell/recovery_basic_gtk.py
+++ b/Dell/recovery_basic_gtk.py
@@ -171,7 +171,8 @@ class BasicGeneratorGTK(DellRecoveryToolGTK):
             #all functions require this at the end
             args += ( self.widgets.get_object('version').get_text(),
                       os.path.join(self.path, self.image),
-                      self.widgets.get_object('platform').get_text() )
+                      self.widgets.get_object('platform').get_text(),
+                      False )
             try:
                 dbus_sync_call_signal_wrapper(self.backend(),
                                 function,

--- a/bto-autobuilder/dell-bto-autobuilder
+++ b/bto-autobuilder/dell-bto-autobuilder
@@ -162,6 +162,9 @@ def parse_argv():
                       default=None,
                       help=('Use specific dell recovery package'))
 
+    parser.add_option('--no-update', action="store_true", dest='no_update',
+                      help=("Don't include newer dell-recovery automatically"))
+
     opts, args = parser.parse_args()
 
     if opts.drivers == None or opts.base == None:
@@ -298,7 +301,8 @@ if __name__ == '__main__':
             'create_ubuntu',                 # called by 'assemble_image'
             current_tag.revision,
             os.path.join(options.bto_dir, bto_name),
-            platform)
+            platform,
+            options.no_update)
 
         print('Build complete: %s' % os.path.join(options.bto_dir, bto_name))
     except dbus.DBusException as err:

--- a/ubiquity/dell-recovery.py
+++ b/ubiquity/dell-recovery.py
@@ -227,7 +227,8 @@ class Install(InstallPlugin):
                                                     rpart,
                                                     version,
                                                     fname,
-                                                    platform)
+                                                    platform,
+                                                    False)
                 os.chown(fname.encode('utf-8'), uid, gid)
             except dbus.DBusException as err:
                 self.log('install function exception while calling backend: %s' % str(err))


### PR DESCRIPTION
…tomatically.

Adding an opt-out option.
It still automatically includes dell-recovery package under debs/ by default if any newer version is available.