### PR TITLE
Renew .disk/ubuntu_dist_channel for ubuntu-report.

### DIFF
--- a/Dell/recovery_backend.py
+++ b/Dell/recovery_backend.py
@@ -980,6 +980,20 @@ arch %s, distributor_str %s, bto_platform %s" % (bto_version, distributor, relea
         xorrisoargs.append('-m')
         xorrisoargs.append(os.path.join('casper', old_initrd))
 
+        #Renew .disk/ubuntu_dist_channel for ubuntu-report
+        ubuntu_dist_channel = os.path.join(mntdir, '.disk', 'ubuntu_dist_channel')
+        if os.path.exists(ubuntu_dist_channel) and platform and revision:
+            xorrisoargs.append('-m')
+            xorrisoargs.append(ubuntu_dist_channel)
+            with open(os.path.join(tmpdir, '.disk', 'ubuntu_dist_channel'), 'w') as target, \
+                 open(ubuntu_dist_channel) as source:
+                for line in source:
+                    if line.startswith('canonical-oem-somerville-') and \
+                            not line.strip().endswith('+' + platform + '+' + revision):
+                        target.write(line.strip() + '+' + platform + '+' + revision + '\n')
+                    else:
+                        target.write(line)
+
         #Restore .disk/info
         info_path = os.path.join(mntdir, '.disk', 'info.recovery')
         if os.path.exists(info_path):

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ dell-recovery (1.60) UNRELEASED; urgency=medium
     by accident.
   * Reduce some PyGIWarning messages.
   * Use the regional mirror site instead of the global mirror site.
+  * Renew .disk/ubuntu_dist_channel for ubuntu-report.
 
  -- Shih-Yuan Lee (FourDollars) <sylee@canonical.com>  Fri, 11 May 2018 18:41:43 +0800
 


### PR DESCRIPTION
Regarding https://bugs.launchpad.net/bugs/1786432, we will use https://bugs.launchpad.net/bugs/1786153 to provide a template for bionic and then using this patch to renew it for the ISO images.

For example,
```
# This is the distribution channel descriptor for the OEM CDs
# For more information see http://wiki.ubuntu.com/DistributionChannelDescriptor
canonical-oem-somerville-bionic-amd64-20180608-47
```
will  become
```
# This is the distribution channel descriptor for the OEM CDs
# For more information see http://wiki.ubuntu.com/DistributionChannelDescriptor
canonical-oem-somerville-bionic-amd64-20180608-47+punisher-whl+X29
```
Next step is to modify the script to generate superset fish tarball so we can track the specific platform by ubuntu-report.