### PR TITLE
Support UBUNTU_DRIVERS_BLACKLIST mechanism in fish tarball.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ dell-recovery (1.60) UNRELEASED; urgency=medium
   * Reduce some PyGIWarning messages.
   * Use the regional mirror site instead of the global mirror site.
   * Renew .disk/ubuntu_dist_channel for ubuntu-report.
+  * Support UBUNTU_DRIVERS_BLACKLIST mechanism in fish tarball.
 
  -- Shih-Yuan Lee (FourDollars) <sylee@canonical.com>  Fri, 11 May 2018 18:41:43 +0800
 


### PR DESCRIPTION
This would like to use a hook to simplify the usage of fish chroot script and fish tarball.

For example, the original nvidia-driver-410.73-0ubuntu0-bionic_fish1.tar.gz looks like the following:

> ./nvidia-id-list
> ./scripts/chroot-scripts/fish/05-gfx-nvidia.sh
> ./nvidia-410.73/\*.deb
> ./prepackage.dell
> ./nvidia-common/\*.deb
> ./prime-select-intel/config-prime-select-intel-all_0.16_all.deb 

After using this mechanism, it will become:

> ./nvidia-id-list
> ./scripts/chroot-scripts/blacklist/05-gfx-nvidia.list
> ./scripts/chroot-scripts/fish/05-gfx-nvidia.sh
> ./prepackage.dell
> ./debs/\*.deb

We would like to gather all Debian packages under ./debs/.