### PR TITLE
add lvm2 and cryptsetup to dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 dell-recovery (1.61) UNRELEASED; urgency=medium
 
+  [ Shih-Yuan Lee (FourDollars) ]
   * Fix the installation problem when the volume name of Intel RSTe SATA RAID
     doesn't end with number. (Closes #67)
   * Make sure the path is set properly in the recovery backend.
@@ -7,7 +8,14 @@ dell-recovery (1.61) UNRELEASED; urgency=medium
   * Support Persistent Memory storage.
   * Support meta by distribution.
 
- -- Shih-Yuan Lee (FourDollars) <sylee@canonical.com>  Thu, 15 Nov 2018 16:23:29 +0800
+  [ Li-Hao Liao (Leon Liao) ]
+  * Query BIOS ID via tag 1.
+
+  [ Yuan-Chen Cheng ]
+  * add lvm2 and cryptsetup to recommends so they won't be removed in
+    encrypted rootfs use case.
+
+ -- Yuan-Chen Cheng <yc.cheng@canonical.com>  Wed, 23 Jan 2019 10:43:06 +0800
 
 dell-recovery (1.60) disco; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -28,9 +28,11 @@ Depends: ${python3:Depends},
          uuid-runtime,
 Replaces: dell-artwork, dell-oobe
 Conflicts: dell-oobe
-Recommends: dvd+rw-tools,
+Recommends: cryptsetup,
+            dvd+rw-tools,
             isolinux,
             lsb-release,
+            lvm2,
             mdadm (>> 4.1~rc1-2),
             parted,
             python3-progressbar,


### PR DESCRIPTION
add lvm2 and cryptsetup to dependency, so that crypted rootfs won't break as user do a "apt autoremove"