### PR TITLE
secureboot: keep original mok for recovery from disk.

### DIFF
--- a/Dell/recovery_backend.py
+++ b/Dell/recovery_backend.py
@@ -146,7 +146,7 @@ class Backend(dbus.service.Object):
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
         if session_bus:
             backend.bus = dbus.SessionBus()
-            backend.enforce_polkit = False
+            backend.enforce_polkit = True
         else:
             backend.bus = dbus.SystemBus()
         try:

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,8 +2,9 @@ dell-recovery (1.60) UNRELEASED; urgency=medium
 
   * Change the order of the kernel parameter options to avoid the propagation
     by accident.
+  * Reduce some PyGIWarning messages.
 
- -- Shih-Yuan Lee (FourDollars) <sylee@canonical.com>  Fri, 11 May 2018 15:11:13 +0800
+ -- Shih-Yuan Lee (FourDollars) <sylee@canonical.com>  Fri, 11 May 2018 18:41:43 +0800
 
 dell-recovery (1.59) bionic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dell-recovery (1.60) UNRELEASED; urgency=medium
+
+  * Change the order of the kernel parameter options to avoid the propagation
+    by accident.
+
+ -- Shih-Yuan Lee (FourDollars) <sylee@canonical.com>  Fri, 11 May 2018 15:11:13 +0800
+
 dell-recovery (1.59) bionic; urgency=medium
 
   [ Shih-Yuan Lee (FourDollars) ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ dell-recovery (1.60) UNRELEASED; urgency=medium
   * Change the order of the kernel parameter options to avoid the propagation
     by accident.
   * Reduce some PyGIWarning messages.
+  * Use the regional mirror site instead of the global mirror site.
 
  -- Shih-Yuan Lee (FourDollars) <sylee@canonical.com>  Fri, 11 May 2018 18:41:43 +0800
 

--- a/grub/99_dell_recovery
+++ b/grub/99_dell_recovery
@@ -21,13 +21,13 @@ menuentry "#RECOVERY_TEXT#" {
         if [ -f /ubuntu.iso ]; then
             loopback loop /ubuntu.iso
             set root=(loop)
-            set options="\$options iso-scan/filename=/ubuntu.iso"
+            set options="iso-scan/filename=/ubuntu.iso \$options"
         fi
         if [ -n "\${lang}" ]; then
-            set options="\$options locale=\$lang"
+            set options="locale=\$lang \$options"
         fi
         if [ -s /factory/dual_enable ]; then
-            set options="\$options dell-recovery/dual_boot=true"
+            set options="dell-recovery/dual_boot=true \$options"
         fi 
 
         linux   /casper/vmlinuz.efi dell-recovery/recovery_type=#REC_TYPE# \$uuid_options \$options

--- a/late/scripts/chroot.sh
+++ b/late/scripts/chroot.sh
@@ -88,10 +88,20 @@ if ! mount | grep "$TARGET/sys"; then
     mount -t sysfs targetsys $TARGET/sys
     MOUNT_CLEANUP="$TARGET/sys $MOUNT_CLEANUP"
 fi
+if ! mount | grep "$TARGET/sys/firmware/efi/efivars"; then
+    mount -t efivarfs efivarfs $TARGET/sys/firmware/efi/efivars
+    MOUNT_CLEANUP="$TARGET/sys/firmware/efi/efivars $MOUNT_CLEANUP"
+fi
 
 if ! mount | grep "$TARGET/cdrom"; then
     mount --bind /cdrom $TARGET/cdrom
     MOUNT_CLEANUP="$TARGET/cdrom $MOUNT_CLEANUP"
+fi
+
+if [ -e /tmp/MOK.priv ] && [ -e /tmp/MOK.der ]; then
+    mkdir -p $TARGET/var/lib/shim-signed/mok
+    cp -f /tmp/MOK.priv /tmp/MOK.der $TARGET/var/lib/shim-signed/mok
+    md5sum $TARGET/var/lib/shim-signed/mok/*
 fi
 
 if [ ! -L $TARGET/media/cdrom ]; then

--- a/late/scripts/pool.sh
+++ b/late/scripts/pool.sh
@@ -90,7 +90,14 @@ fi
 
 if [ "$1" = "cleanup" ]; then
     #cleanup
-    mv /etc/apt/sources.list.ubuntu /etc/apt/sources.list
+    #if /etc/apt/sources.list has contained the regional mirror site, it is better to use it.
+    if grep -v "^#" /etc/apt/sources.list | grep archive.ubuntu.com >/dev/null 2>&1; then
+        rm -f /etc/apt/sources.list.ubuntu
+        # Ensure Canonical's 'partner' repository enabled.
+        sed -i 's/# deb \(.*\) partner$/deb \1 partner/g' /etc/apt/sources.list
+    else
+        mv /etc/apt/sources.list.ubuntu /etc/apt/sources.list
+    fi
     rm -f /Packages /etc/apt/apt.conf.d/00AllowUnauthenticated /etc/apt/apt.conf.d/00NoMountCDROM
     rm -f /etc/apt/sources.list.d/dell.list
     if [ -d /etc/apt/sources.list.d.old ]; then

--- a/late/scripts/wodim-iso.py
+++ b/late/scripts/wodim-iso.py
@@ -20,6 +20,10 @@ import math, os, re, subprocess, sys, threading
 
 from gettext import gettext as _
 from gettext import textdomain
+
+import gi
+gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
 from gi.repository import GObject, Gdk, Gtk
 
 if os.getgid() == 0:


### PR DESCRIPTION
operation in this chage:
 1. if there's existed mok key in old rootfs, then copy it to
/var/lib/shim-signed/mok
 2. bind mount /sys/firmware/efi/efivars to target, because it will be
used by mokutil --test-key.