### PR TITLE
Refine the wording of the entry of full disk encryption during instal…

### DIFF
--- a/debian/dell-recovery.templates
+++ b/debian/dell-recovery.templates
@@ -78,11 +78,15 @@ _Description: WARNING: All personal files and changes will be lost.
 
 Template: ubiquity/text/interactive_recovery
 Type: text
-_Description: Restore only Linux OS partition.
+_Description: Customize installation.
 
 Template: ubiquity/text/interactive_info
 Type: text
-_Description: This option allows you to resize any existing partitions.
+_Description: e.g. Disk encryption, partitions resizing..etc.
+
+Template: ubiquity/text/nonrecovery_warning_label
+Type: text
+_Description: WARNING: No recovery feature included.
 
 Template: ubiquity/text/genuine_bootstrap_warning_label
 Type: text

--- a/ubiquity/stepDellBootstrap.ui
+++ b/ubiquity/stepDellBootstrap.ui
@@ -515,7 +515,7 @@
                 <property name="spacing">5</property>
                 <child>
                   <object class="GtkRadioButton" id="interactive_recovery">
-                    <property name="label" translatable="yes">Restore only Linux OS partition.</property>
+                    <property name="label" translatable="yes">Customize installation.</property>
                     <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -544,7 +544,7 @@
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
                         <property name="yalign">0</property>
-                        <property name="label" translatable="yes">This option allows you to resize any existing partitions.</property>
+                        <property name="label" translatable="yes">e.g. Disk encryption, partitions resizing..etc.</property>
                         <property name="use_markup">True</property>
                         <property name="wrap">True</property>
                       </object>
@@ -554,6 +554,30 @@
                     <property name="expand">False</property>
                     <property name="fill">False</property>
                     <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkAlignment" id="alignment9">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">25</property>
+                    <child>
+                      <object class="GtkLabel" id="nonrecovery_warning_label">
+                        <property name="width_request">600</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                        <property name="label" translatable="yes">WARNING: No recovery feature included.</property>
+                        <property name="use_markup">True</property>
+                        <property name="wrap">True</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>


### PR DESCRIPTION
Refine the wording of the entry of full disk encryption during installation

Because of the wording is confusing people to find out an entry to do full disk encryption, so this patch is to refine it.

before:
http://i.imgur.com/GVgCzwZ.png

after:
http://i.imgur.com/g08SLbs.png
