### PR TITLE
dell-bootstrap: use distro policy for swap (Fixes: #82) (LP: #1842325)

### DIFF
--- a/casper/seeds/ubuntu.seed
+++ b/casper/seeds/ubuntu.seed
@@ -93,12 +93,7 @@
        format{ }                       \
        use_filesystem{ }               \
        filesystem{ ext4 }              \
-       mountpoint{ / } .               \
-                                       \
-       105% 150% 200% linux-swap       \
-       method{ swap }                  \
-       format{ }                       \
-       .
+       mountpoint{ / } .
 
 # In case we decide to remove swap from a drive in FI:
  d-i partman-basicfilesystems/no_swap boolean false

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -364,12 +364,8 @@ class Page(Plugin):
         release = lsb_release.get_distro_information()
 
         #starting with 17.04, we replace the whole swap partition to swap file
+        #use distro policy to determine what to do.
         if float(release["RELEASE"]) >= 17.04:
-            try:
-                self.db.set('partman-swapfile/percentage', '50')
-                self.db.set('partman-swapfile/size', self.mem * 2048)
-            except debconf.DebconfError as err:
-                self.log(str(err))
             return True
 
         if (self.mem >= 32 or self.disk_size <= 64):


### PR DESCRIPTION
It's much better than what we were adopting (needlessly wasting space)
> Secondly, the sizing of swapfiles is very different. It is no more than 5% of free disk space or 2GiB, whichever is lower.

See https://blog.surgut.co.uk/2016/12/swapfiles-by-default-in-ubuntu.html
for more details.