### PR TITLE
Avoid bto build failure

### DIFF
--- a/Dell/recovery_common.py
+++ b/Dell/recovery_common.py
@@ -530,7 +530,10 @@ def create_new_uuid(old_initrd_directory, old_casper_directory,
 
     #Detect compression
     lines = ''
-    root = os.path.join(tmpdir, 'main', 'conf', 'initramfs.conf')
+    if os.path.isdir(os.path.join(tmpdir, 'main')):
+        root = os.path.join(tmpdir, 'main', 'conf', 'initramfs.conf')
+    else:
+        root = os.path.join(tmpdir, 'conf', 'initramfs.conf')
     with open(root, 'r') as rfd:
         lines = rfd.readlines()
     new_compression = ''


### PR DESCRIPTION
When the initramfs.conf is not in main/conf, the bto build will stop.
I checked the initrd in focal, the initramfs.conf is in conf.
Add the condition to make the flexibility.