### PR TITLE
Using `dpkg-query -W $pkg` is unreliable.

### DIFF
--- a/late/chroot_scripts/03-ubuntu-drivers.sh
+++ b/late/chroot_scripts/03-ubuntu-drivers.sh
@@ -12,14 +12,14 @@ done
 if [ -n "$UBUNTU_DRIVERS_BLACKLIST" ]; then
     echo "UBUNTU_DRIVERS_BLACKLIST: $UBUNTU_DRIVERS_BLACKLIST"
 fi
-for pkg in `ubuntu-drivers list`; do
-    if dpkg-query -W $pkg >/dev/null 2>&1; then
+for pkg in $(ubuntu-drivers list); do
+    if dpkg-query -W -f='${Status}\n' "$pkg" | grep "install ok installed" >/dev/null 2>&1; then
         echo "$pkg has been installed."
     else
-        if [ -n "$UBUNTU_DRIVERS_BLACKLIST" ] && echo "$UBUNTU_DRIVERS_BLACKLIST" | grep $pkg >/dev/null 2>&1; then
+        if [ -n "$UBUNTU_DRIVERS_BLACKLIST" ] && echo "$UBUNTU_DRIVERS_BLACKLIST" | grep "$pkg" >/dev/null 2>&1; then
             echo "Won't install '$pkg' listed in UBUNTU_DRIVERS_BLACKLIST"
         else
-            apt-get install --yes $pkg
+            apt-get install --yes "$pkg"
         fi
     fi
 done


### PR DESCRIPTION
Using `dpkg-query -W -f='${Status}\n' $pkg | grep "install ok installed"` instead.

We met some problem when dealing with the logo customization.

$ sudo dpkg -i dell-canonical-estar-logo_1_all.deb 
(Reading database ... 152000 files and directories currently installed.)
Preparing to unpack dell-canonical-estar-logo_1_all.deb ...
Removing 'diversion of /usr/share/icons/hicolor/256x256/apps/ubuntu-logo-icon.png to /usr/share/icons/hicolor/256x256/apps/ubuntu-logo-icon.png.gnome-conrol-center-data by dell-canonical-estar-logo'
Unpacking dell-canonical-estar-logo (1) over (1) ...
Setting up dell-canonical-estar-logo (1) ...
Adding 'diversion of /usr/share/icons/hicolor/256x256/apps/ubuntu-logo-icon.png to /usr/share/icons/hicolor/256x256/apps/ubuntu-logo-icon.png.gnome-conrol-center-data by dell-canonical-estar-logo'

$ dpkg-query -W dell-canonical-estar-logo
dell-canonical-estar-logo	1

$ dpkg-query -W dell-canonical-mcmc-logo
dell-canonical-mcmc-logo

dell-canonical-mcmc-logo and dell-canonical-estar-logo come from the same source package.
While we only installed dell-canonical-estar-logo, we can still dpkg-query -W dell-canonical-mcmc-logo and get the output for dell-canonical-mcmc-logo.
So we need to use other specific way to check the installed package.
