### PR TITLE
Retire the dell-$BIOS_ID-meta

### DIFF
--- a/late/chroot_scripts/03-ubuntu-drivers.sh
+++ b/late/chroot_scripts/03-ubuntu-drivers.sh
@@ -23,15 +23,5 @@ for pkg in $(ubuntu-drivers list | awk -F'[ ,]' '{print $1}'); do
         fi
     fi
 done
-
-#install meta package based upon BIOS ID
-BIOS_ID=$(dmidecode -t 11 | sed '/ 1\[/!d; s,.* 1\[,,; s,\],,' | tr A-Z a-z)
-SERIES=$(lsb_release -cs)
-for pkg in dell-$BIOS_ID-meta dell-$BIOS_ID-$SERIES-meta; do
-    if ! dpkg-query -W $pkg >/dev/null 2>&1; then
-        apt-get install --yes $pkg || true
-    fi
-done
-
 rm /etc/apt/apt.conf.d/99disable_authentication
 IFHALT "Done with ubuntu-drivers autoinstall"


### PR DESCRIPTION
Since the dell-$BIOS_ID-meta is retired, we remove the install script.