### PR TITLE
fix model naming retrival for Intel® Optane Memory H10 with Solid Sta…

### DIFF
--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -591,6 +591,8 @@ class Page(Plugin):
             elif device_path.startswith('/dev/nvme'):
                 output = block.get_cached_property("Id").get_string()
                 model = output.split("-")[-1].replace("_", " ")
+                if len(model) < 4:
+                    model = output.split("-")[-2].replace("_", " ")
                 nvme_dev_size = block.get_cached_property("Size").unpack()
                 disks.append([device_path, nvme_dev_size, "%s (%s)" % (model, device_path)])
                 continue


### PR DESCRIPTION
output string for the module is:

'by-id-nvme-H10_HBRPEKNX0202A_NVMe_INTEL_512GB_BTTE95040ABZ512B-1'
'by-id-nvme-H10_HBRPEKNX0202AO_NVMe_INTEL_32GB_BTTE95040ABZ512B-2'

with the code logic, model name will be "1" and "2"

the patch is not perfect, but works.

Maybe try to find some other method works better.