### PR TITLE
Focal optane fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dell-recovery (1.64somerville4) focal; urgency=medium
+
+  * ubiquity/dell-bootstrap.py: cherry-pick commit that properly show model
+    name of certain optane modules.
+
+ -- Yuan-Chen Cheng <yc.cheng@canonical.com>  Fri, 22 May 2020 16:43:29 +0800
+
 dell-recovery (1.64somerville3) focal; urgency=medium
 
   [ Li-Hao Liao (Leon Liao) ]

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -591,6 +591,8 @@ class Page(Plugin):
             elif device_path.startswith('/dev/nvme'):
                 output = block.get_cached_property("Id").get_string()
                 model = output.split("-")[-1].replace("_", " ")
+                if len(model) < 4:
+                    model = output.split("-")[-2].replace("_", " ")
                 nvme_dev_size = block.get_cached_property("Size").unpack()
                 disks.append([device_path, nvme_dev_size, "%s (%s)" % (model, device_path)])
                 continue


### PR DESCRIPTION
dell-recovery (1.64somerville4) focal; urgency=medium

  * ubiquity/dell-bootstrap.py: cherry-pick commit that properly show model
    name of certain optane modules.

 -- Yuan-Chen Cheng <yc.cheng@canonical.com>  Fri, 22 May 2020 16:43:29 +0800