### PR TITLE
delay 5 seconds for go_forward in dev mode to make it more reliable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dell-recovery (1.67) UNRELEASED; urgency=medium
+
+  [ Crag Wang ]
+  * stage2: remove directory $TARGET/pts
+
+  [ Yuan-Chen Cheng ]
+  * ubiquity/dell-bootstrap.py: delay 5 seconds in dev mode to make it more
+    reliable, especially for Recovery from hdd.
+
+ -- Yuan-Chen Cheng <yc.cheng@canonical.com>  Fri, 25 Sep 2020 11:34:11 +0800
+
 dell-recovery (1.66) groovy; urgency=medium
 
   [ Shih-Yuan Lee (FourDollars)]

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -250,12 +250,14 @@ class PageGtk(PluginUI):
                 self.interactive_recovery.set_sensitive(False)
                 self.automated_recovery.set_sensitive(False)
                 self.dhc_automated_recovery.set_sensitive(False)
-            if value == "dev" and (not hdd_flag):
+            if value == "dev" and (not hdd_flag): # USB installation, stage 2
                 self.automated_recovery.set_active(True)
-                self.controller.go_forward()
-            elif value == "dev" and hdd_flag:
+                self.controller.allow_go_forward(True)
+                GLib.timeout_add(5000, self.controller.go_forward)
+            elif value == "dev" and hdd_flag: # Recovery from hdd.
                 self.hdd_recovery.set_active(True)
-                self.controller.go_forward()
+                self.controller.allow_go_forward(True)
+                GLib.timeout_add(5000, self.controller.go_forward)
             else:
                 self.controller.allow_go_forward(False)
 


### PR DESCRIPTION
ubiquity/dell-bootstrap.py: delay 5 seconds in dev mode to make it more
reliable, especially for Recovery from hdd.

use the code with this patch in dev environment for quite a while and works well.