### PR TITLE
late/scripts/chroot.sh: syntax error fix

### DIFF
--- a/late/scripts/chroot.sh
+++ b/late/scripts/chroot.sh
@@ -81,7 +81,7 @@ if ! mount | grep "$TARGET/run"; then
     MOUNT_CLEANUP="$TARGET/run $MOUNT_CLEANUP"
 fi
 if ! mount | grep "$TARGET/pts"; then
-    if ! -e "$TARGET/pts"; then
+    if [ ! -e "$TARGET/pts"]; then
         mkdir -p "$TARGET/pts"
         DIR_CLEANUP="$TARGET/pts $DIR_CLEANUP"
     fi


### PR DESCRIPTION
error log in chroot.sh.log

+ grep /target/pts
+ -e /target/pts
/usr/share/dell/scripts/chroot.sh: 84: -e: not found
+ mkdir -p /target/pts
+ DIR_CLEANUP=/target/pts 

I think this commit fix this issue.