### PR TITLE
fix for syntax error, and remove the checks for unused boot files

### DIFF
--- a/Dell/recovery_backend.py
+++ b/Dell/recovery_backend.py
@@ -956,8 +956,6 @@ arch %s, distributor_str %s, bto_platform %s" % (bto_version, distributor, relea
             xorrisoargs.append('-boot-info-table')
             xorrisoargs.append('-isohybrid-mbr')
             xorrisoargs.append(os.path.join('/', 'usr', 'lib', 'ISOLINUX', 'isohdpfx.bin'))
-        else:
-            raise CreateFailed("Unable to locate isolinux to build hybrid MBR")
 
         #include bootloader as eltorito if we have it
         if os.path.exists(os.path.join(mntdir, 'boot', 'grub', 'efi.img')):
@@ -972,9 +970,6 @@ arch %s, distributor_str %s, bto_platform %s" % (bto_version, distributor, relea
             xorrisoargs.append('boot/efi.img')
             xorrisoargs.append('-no-emul-boot')
             xorrisoargs.append('-isohybrid-gpt-basdat')
-        else:
-            raise CreateFailed("Unable to locate EFI bootloader image")
-
 
         #disable 32 bit bootloader if it was there.
         grub_path = os.path.join(mntdir, 'boot', 'grub', 'i386-pc')

--- a/late/scripts/chroot.sh
+++ b/late/scripts/chroot.sh
@@ -81,7 +81,7 @@ if ! mount | grep "$TARGET/run"; then
     MOUNT_CLEANUP="$TARGET/run $MOUNT_CLEANUP"
 fi
 if ! mount | grep "$TARGET/pts"; then
-    if [ ! -e "$TARGET/pts"]; then
+    if [ ! -e "$TARGET/pts" ]; then
         mkdir -p "$TARGET/pts"
         DIR_CLEANUP="$TARGET/pts $DIR_CLEANUP"
     fi
@@ -141,13 +141,13 @@ chroot $TARGET /usr/share/dell/scripts/target_chroot.sh
 
 for mountpoint in $MOUNT_CLEANUP;
 do
-    umount -l $mountpoint
+    umount -l "$mountpoint"
 done
 unset MOUNT_CLEANUP
 
 for directory in $DIR_CLEANUP;
 do
-    rm -rf $directory
+    rm -rf "$directory"
 done
 
 chroot $TARGET chattr -a $LOG/chroot.sh.log
@@ -176,4 +176,4 @@ fi
 # reset traps, as we are now exiting normally
 trap - TERM INT HUP EXIT QUIT
 
-. /usr/share/dell/scripts/SUCCESS-SCRIPT $BOOT_DEV $BOOT_PART_NUM
+. /usr/share/dell/scripts/SUCCESS-SCRIPT


### PR DESCRIPTION
With recent build of Ubuntu official releases, e.g. Ubuntu Desktop 20.10, missing `isolinux` directory nor `efi.img` file that were referenced previously.

Running `dell-recovery --builder` with Ubuntu 20.10 based ISO will get errors, for example:
```
Unable to locate isolinux to build hybrid MBR
```
and
```
Unable to locate EFI bootloader image
```