### PR TITLE
Getting BIOS ID from the subsystem device of i2c device

### DIFF
--- a/late/chroot_scripts/03-ubuntu-drivers.sh
+++ b/late/chroot_scripts/03-ubuntu-drivers.sh
@@ -12,7 +12,8 @@ done
 if [ -n "$UBUNTU_DRIVERS_BLACKLIST" ]; then
     echo "UBUNTU_DRIVERS_BLACKLIST: $UBUNTU_DRIVERS_BLACKLIST"
 fi
-BIOSID=$(cut -c 3-6 < /sys/bus/pci/devices/0000:00:00.0/subsystem_device)
+# Use the i2c device's subsystem ID as the BIOS ID.
+BIOSID=$(cut -c 3-6 < "$(dirname "$(find /sys -name modalias -exec echo {} \; -exec cat {} \; | grep bc0Csc05 -B 1 | head -n 1)")/subsystem_device")
 for pkg in $(ubuntu-drivers list | awk -F'[ ,]' '{print $1}'); do
     if apt-cache show "$pkg" | grep ^Modaliases | grep -i "sv00001028sd0000$BIOSID" >/dev/null 2>&1; then
         factory="${pkg/oem-somerville/oem-somerville-factory}"


### PR DESCRIPTION
Getting BIOS ID from the subsystem device of host bridge is still
problematic so getting BIOS ID from the subsystem device of i2c device instead.