### PR TITLE
add seed value for minimal recovery partition size.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ dell-recovery (1.67) UNRELEASED; urgency=medium
   [ Yuan-Chen Cheng ]
   * ubiquity/dell-bootstrap.py: delay 5 seconds in dev mode to make it more
     reliable, especially for Recovery from hdd.
+  * add seed value for minimal recovery partition size.
 
  -- Yuan-Chen Cheng <yc.cheng@canonical.com>  Fri, 25 Sep 2020 11:34:11 +0800
 

--- a/debian/dell-recovery.templates
+++ b/debian/dell-recovery.templates
@@ -24,6 +24,11 @@ Default: dynamic
 Description: for internal use;determines whether to offer the bootstrap 
  ubiquity plugin to the user. valid: [dynamic, factory, usb, dvd]
 
+Template: dell-recovery/recovery_size
+Type: string
+Default: 0
+Description: recovery partition size in M. default 0 means the installer size + cushion.
+
 Template: dell-recovery/build_start
 Type: text
 _Description: Building Dell Recovery Media...


### PR DESCRIPTION
Add seed value for the minimal recovery partition size. This is useful for the development phase.
This is tested in the focal branch and it works fine.
The preseed sample like:

dell-recovery dell-recovery/recovery_size string 6144