### PR TITLE
Don't install packages from external archive in prepare page

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
 dell-recovery (1.68) focal; urgency=medium
 
+  [ Kai-Chuan Hsieh ]
+  * Don't install packages from external archive in prepare page (LP: #1993367)
+
   [ Alex Tu ]
   * support Intel and AMD dev board (Closes #138)
 

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -893,7 +893,7 @@ class Page(Plugin):
             self.preseed("ubiquity/minimal_install", "true")
 
         self.preseed_bool("ubiquity/download_updates", False)
-        self.preseed_bool("ubiquity/use_nonfree", True)
+        self.preseed_bool("ubiquity/use_nonfree", False)
 
         return (['/usr/share/ubiquity/dell-bootstrap'], [RECOVERY_TYPE_QUESTION])
 


### PR DESCRIPTION
LP: #1993367

To set ubiquity/use_nonfree to True will install required packages from external archive if system has Nvidia graphic.
It is always failed to install gcc-12-base:i386. Therefore, we don't need to take this action during verifying installation configuration.
More, the page will be stuck eternally in Dell's FI environment.