### PR TITLE
Don't install packages from external archive in prepare page

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dell-recovery (1.68somerville10) jammy; urgency=medium
+
+  * Don't install packages from external archive
+
+ -- Kai-Chuan Hsieh <kaichuan.hsieh@canonical.com>  Thu, 27 Oct 2022 09:53:56 +0800
+
 dell-recovery (1.68somerville9) jammy; urgency=medium
 
   * Fix installations on eMMC drives.

--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -893,7 +893,7 @@ class Page(Plugin):
             self.preseed("ubiquity/minimal_install", "true")
 
         self.preseed_bool("ubiquity/download_updates", False)
-        self.preseed_bool("ubiquity/use_nonfree", True)
+        self.preseed_bool("ubiquity/use_nonfree", False)
 
         return (['/usr/share/ubiquity/dell-bootstrap'], [RECOVERY_TYPE_QUESTION])
 


### PR DESCRIPTION
https://bugs.launchpad.net/somerville/+bug/1993367

It tries to install Nvidia driver required package during verifying installation configuration. The procedure will be stuck in Dell FI environment. Set it to false to omit the ubuntu-drivers install on DGPU config.