### PR TITLE
dell-bto-autobuilder: make python3-progressbar optional

### DIFF
--- a/bto-autobuilder/dell-bto-autobuilder
+++ b/bto-autobuilder/dell-bto-autobuilder
@@ -18,11 +18,12 @@ from Dell.recovery_common import DBUS_BUS_NAME, DBUS_INTERFACE_NAME, \
                                  dbus_sync_call_signal_wrapper
 import dbus.mainloop.glib
 
+progressbar = None
 try:
     import progressbar
 except ImportError:
-    print('Error: python3-progressbar is not installed', file=sys.stderr)
-    sys.exit(1)
+    print('python3-progressbar is not installed.  ' \
+            'Progress bar will not be displayed.', file=sys.stderr)
 
 class FidTag:
     ''' Convenience class that cleans up how the Dell FID
@@ -90,15 +91,18 @@ class Install:
     def __init__(self):
         self.old_state = 'starting progress tracking'
         self.state = None
-        self.progress = progressbar.ProgressBar()
-        self.progress.start()
+        self.progress = None
+        if progressbar is not None:
+            self.progress = progressbar.ProgressBar()
+            self.progress.start()
 
     def update_percent(self, state, num):
         self._print_once(state)
-        if num < 100:
-            self.progress.update(num)
-        else:
-            self.progress.finish()
+        if self.progress is not None:
+            if num < 100:
+                self.progress.update(num)
+            else:
+                self.progress.finish()
 
     def update_plain(self, state):
         self._print_once(state)

--- a/debian/control
+++ b/debian/control
@@ -44,12 +44,12 @@ Recommends: cd-boot-images-amd64,
             mokutil,
             mdadm (>> 4.1~rc1-2),
             parted,
-            python3-progressbar,
             usb-creator-gtk,
             wodim,
             xorriso,
 Enhances: oem-config-gtk, ubiquity-frontend-gtk
-Suggests: grub-pc
+Suggests: grub-pc,
+          python3-progressbar,
 Description: Dell Recovery Media Creation Package
  This package is used to produce a Dell recovery media image.
  It then uses known open source tools to write the image to


### PR DESCRIPTION
python3-progressbar is not in main/restricted and we would like to reduce the usage of packages that's not supported by Canonical.  Hence, we would like to make it optional.