### PR TITLE
Fix disks order by display string if the size are the same

### DIFF
--- a/ubiquity/dell-bootstrap.py
+++ b/ubiquity/dell-bootstrap.py
@@ -384,7 +384,13 @@ def disk_sort_comp(d1, d2):
 
     d1_key, d2_key = disk_type_key(d1), disk_type_key(d2)
     if d1_key == d2_key:
-        return d2[1] - d1[1]
+        if d1[1] == d2[1]:
+            if d1[2] > d2[2]:
+                return 1
+            else:
+                return -1
+        else:
+            return d2[1] - d1[1]
     else:
         return d2_key - d1_key
 


### PR DESCRIPTION
When the platform has multiple disk in the same type and size, the order is not fixed. It leads the user format unexpected disk without caution.

The display string contains serial for nvme and unique ID for other type. Fix the order by display string if the type and size are the same.

https://bugs.launchpad.net/somerville/+bug/2047010